### PR TITLE
Fix "More Information" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#Send Email
+# Send Email
 This extension takes care of sending email within your build or release pipeline
 
-##What can you do
+## What can you do
 * Send email to 1 or more addresses (To, CC and BCC)
-* Configure a SMTP server 
+* Configure a SMTP server
 
 *27-03-2017*
 Added the possibility to send email to CC and BCC as well
@@ -16,7 +16,7 @@ Fixed a bug that build variables are not expanded in the build body and subject 
 *2-9-2016*
 Added Anonymous authentication. Leave the username and password field blank to send with anonymous access
 
-##More information
+## More information
 Source can be found here on [Github](https://github.com/renevanosnabrugge/SendEmail-BuildTask)
 
 Follow my blog for updates [Road to ALM](http://www.roadtoalm.com)

--- a/SendEmail/task.json
+++ b/SendEmail/task.json
@@ -3,7 +3,7 @@
   "name": "SendEmail",
   "friendlyName": "Send email",
   "description": "Send an email to 1 or more addresses via the SMTP server you provide",
-  "helpMarkDown": "Version: __VERSION__. [More information](http://github.com/rvanosnabrugge)",
+  "helpMarkDown": "Version: __VERSION__. [More information](https://github.com/renevanosnabrugge/SendEmail-BuildTask)",
   "category": "Utility",
   "author": "R. van Osnabrugge",
   "version": {
@@ -132,7 +132,7 @@
       "required": false,
       "groupName": "smtpsettings",
       "helpMarkDown": "Port to the SMTP server"
-    },	
+    },
     {
       "name": "SmtpUsername",
       "type": "string",


### PR DESCRIPTION
Fix the link that appears in the task editor as  "More information" to point to GitHub and the correct repository. 