### PR TITLE
Fix link to GitHub repo in V1 & V2 of the tasks.json

### DIFF
--- a/SendEmail/task.json
+++ b/SendEmail/task.json
@@ -4,7 +4,7 @@
   "name": "SendEmail",
   "friendlyName": "#{PrivatePublicExtension}#Send email",
   "description": "Send an email to 1 or more addresses via the SMTP server you provide",
-  "helpMarkDown": "Version: #{PrivatePublicExtension}##{Build.BuildNumber}#. [More information](http://github.com/rvanosnabrugge)",
+  "helpMarkDown": "Version: #{PrivatePublicExtension}##{Build.BuildNumber}#. [More information](https://github.com/renevanosnabrugge)",
   "category": "Utility",
   "author": "Rene van Osnabrugge",
   "version": {

--- a/SendEmailV2/task.json
+++ b/SendEmailV2/task.json
@@ -4,7 +4,7 @@
     "name": "SendEmail",
     "friendlyName": "#{PrivatePublicExtension}#Send email",
     "description": "Send an email to 1 or more addresses via the SMTP server you provide",
-    "helpMarkDown": "Version: #{PrivatePublicExtension}##{Build.BuildNumber}#. [More information](http://github.com/rvanosnabrugge)",
+    "helpMarkDown": "Version: #{PrivatePublicExtension}##{Build.BuildNumber}#. [More information](https://github.com/renevanosnabrugge)",
     "category": "Utility",
     "author": "Rene van Osnabrugge",
     "version": {


### PR DESCRIPTION
This pull request includes changes to update the URL in the `helpMarkDown` field for two task configuration files. The URL has been updated from `http://github.com/rvanosnabrugge` to `https://github.com/renevanosnabrugge`.

* [`SendEmail/task.json`](diffhunk://#diff-6e472b3bc508336e8c1c9c27b0e4772d6440fee270b2ec333d49df67cf1ba637L7-R7): Updated the `helpMarkDown` URL to use HTTPS and the correct GitHub username.
* [`SendEmailV2/task.json`](diffhunk://#diff-b1a4ca4baf87734ee185590108503d54f594066cb8050bb052082785666b6671L7-R7): Updated the `helpMarkDown` URL to use HTTPS and the correct GitHub username.