### PR TITLE
Changes suggested to allow extension to run on other platforms

### DIFF
--- a/SendEmailV2/task.json
+++ b/SendEmailV2/task.json
@@ -161,10 +161,12 @@
     "instanceNameFormat": "Send an email with subject $(Subject)",
     "execution": {
       "Node16": {
-        "target": "index.js"
+        "target": "index.js",
+        "platform": "linux, macos, windows"
       },
       "Node20_1": {
-        "target": "index.js"
+        "target": "index.js",
+        "platform": "linux, macos, windows"
       }
     }
   }


### PR DESCRIPTION
Currently the extension only supports Windows. This was the suggested solution to resolve the error that the task was only supported on Windows only. #59 is the issue we're hoping to resolve with this pull request.